### PR TITLE
correct start here link in template

### DIFF
--- a/level-1.php
+++ b/level-1.php
@@ -27,7 +27,7 @@ get_header(); ?>
 
 <div class="grid-within-grid-two-item pad-large text-large">
 
-          <div>Unfamiliar with archives? <a href="/records/start-here.htm" class="text-yellow">Start here</a> 
+          <div>Unfamiliar with archives? <a href="/help-with-your-research/start-here/" class="text-yellow">Start here</a> 
           </div>
  
 


### PR DESCRIPTION
Argh! Content links shouldn't be in templates!
This has been fixed in the DEVLB, LIVELB and TESTLB environments.
