### PR TITLE
Take alt text from the image attachment

### DIFF
--- a/education-bundle-document-viewer.php
+++ b/education-bundle-document-viewer.php
@@ -59,7 +59,10 @@ $nextID = ( isset($pages[$current+1]) ) ? $pages[$current+1] : '';
               <?php 
     
      $large_image_url = wp_get_attachment_image_src( get_post_thumbnail_id(), 'full');
- echo '<a href="' . $large_image_url[0] . '" title="Full image of ' . the_title_attribute('echo=0') . '" target="_blank" >';
+     $large_image_alt = get_post_meta(get_post_thumbnail_id(), '_wp_attachment_image_alt', true);
+     $large_image_alt = ($large_image_alt ? $large_image_alt : "Full image of " . the_title_attribute('echo=0'));
+
+ echo '<a href="' . $large_image_url[0] . '" title="' . $large_image_alt . '" target="_blank" >';
    the_post_thumbnail('full', array('class' => 'bundle-full')); ?>
 
 


### PR DESCRIPTION
Hi Chris,

Could you look over this and feel free to shout/fix if I've done anything horrendous!

Basically the idea is to use the alt text if it exists otherwise it creates alt text from the title of the resource.