### PR TITLE
Remove url encoded hyphen so blog search works

### DIFF
--- a/keepers-gallery-template.php
+++ b/keepers-gallery-template.php
@@ -147,7 +147,7 @@ get_header();
                 <div class="breather separator">
                     <h3>Keeper's Gallery blog</h3>
 
-                    <p>To find out more about our latest exhibits, read our Keeper's Gallery <a href="http://blog.nationalarchives.gov.uk/?s=keeper's+gallery">blog series</a>.
+                    <p>To find out more about our latest exhibits, read our Keeper's Gallery <a href="https://blog.nationalarchives.gov.uk/?s=keeper's+gallery">blog series</a>.
                     </p>
                 </div>
 


### PR DESCRIPTION
OK - not sure whether it would be better to fix the blog side of things!

The problem is that the link to keepers gallery blog posts in this template uses an encoded search term, so
http://blog.nationalarchives.gov.uk/?s=keeper%27s+gallery

Blog search is interpreting this literally and therefore finding nothing - changing the link to:
http://blog.nationalarchives.gov.uk/?s=keeper's+gallery

fixes the problem so I have done this in the first instance - if you think this would be better getting blog to recognise an URL encoded search string feel free to reject this PR.