### PR TITLE
Removing yellow tag from selected keyword to avoid user confusion

### DIFF
--- a/inc/research-guide-filter/research-guide-filter-logic.php
+++ b/inc/research-guide-filter/research-guide-filter-logic.php
@@ -282,7 +282,7 @@ function generateTags($arrayOfTerms, $reskeyword = false) {
 			$strfirstletter = substr($term->slug,0,1);
 
 			if ($strslug == $reskeyword){
-				$tags[] = sprintf("<span class='tag hue-50-yellow'><a href='/help-with-your-research/research-guides-keywords/?show=keywords&keyword-letter=%s&keyword=%s#guidance' title='Show all research guides tagged %s'>%s</a></span>", $strfirstletter, $strslug, $strtag, $strtag);
+				$tags[] = sprintf("<span class='tag'><a href='/help-with-your-research/research-guides-keywords/?show=keywords&keyword-letter=%s&keyword=%s#guidance' title='Show all research guides tagged %s'>%s</a></span>", $strfirstletter, $strslug, $strtag, $strtag);
 
 			} else {
 


### PR DESCRIPTION
Hi @matt-blair,

can you check this for me - just removing a class from the tag (as users have been clicking on the yellow highlight and getting stuck in loops) .

Thanks,
Simon