### PR TITLE
Removed unnecessary array that caused problems

### DIFF
--- a/home-with-external-links.php
+++ b/home-with-external-links.php
@@ -86,7 +86,7 @@ get_header(); ?>
                         <a href="<?php echo $link ?>" title="<?php echo $title ?>"> <div class="float-right starts-at-full ends-at-half thumbnail-container-lrg">
                                 <img src="<?php echo $image ?>" alt="<?php echo strtolower($title); ?>" /></div></a>
                         <p>
-                            <?php echo $description[$i] ?>
+                            <?php echo $description ?>
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
The array was being treated as a string array in the title tag and was tehrefore only showing the first character of the array - I could see no reason to put the content into an array (it doesn't get reused outside of the for loop) so I've simplified the template by removing the array which fixed the problem.