### PR TITLE
remove dot from custom-field name

### DIFF
--- a/research-guide-in-depth.php
+++ b/research-guide-in-depth.php
@@ -20,7 +20,7 @@ get_header(); ?>
     <div class="col starts-at-full ends-at-two-thirds box clr">
       <h1 class="margin-none"><span><span>
 <?php
-$alttitle = '2.title-prefix';
+$alttitle = '2-title-prefix';
 $thealttitle = get_post_meta($post->ID, $alttitle, TRUE);
 if($thealttitle != '') {
 echo ($thealttitle);

--- a/research-guide-introductory.php
+++ b/research-guide-introductory.php
@@ -15,7 +15,7 @@ get_header(); ?>
   <div class="row">
     <div class="col starts-at-full ends-at-two-thirds box clr">
       <h1 class="margin-none"><span><span><?php
-$alttitle = '2.title-prefix';
+$alttitle = '2-title-prefix';
 $thealttitle = get_post_meta($post->ID, $alttitle, TRUE);
 if($thealttitle != '') {
 echo ($thealttitle);


### PR DESCRIPTION
It seems that in a recent upgrade ACF decided to not allow dots (.) in custom field names and just deleted them all :-( - this is the first problem that this has caused - there are likely to be more.

This allows to change the title prefix on research guides - the ACF configuration in the back end needs to be changed as well.