### PR TITLE
Update research guide form replacement string to point to c-test

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -408,7 +408,7 @@ if (!function_exists('render_form')) :
 
                 $pattern = '/(action="https?:\/\/)(discovery\.nationalarchives\.[^"]*")/';
 
-                return preg_replace($pattern, '$1test.$2', $file_content);
+                return preg_replace($pattern, '$1ctest-$2', $file_content);
             }
             return $file_content;
 


### PR DESCRIPTION
The new URL for Discovey test is `c-test` rather than `test`. This updates replacement string that is which is used to update the action attribute of research guide forms.