### PR TITLE
Update tna-components to v1.1.4

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -96,7 +96,7 @@ if (!function_exists('tna_dev_scripts')) :
         //wp_enqueue_script('tna-dev-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '20120206', true);
 
         wp_enqueue_script('tna-dev-skip-link-focus-fix', str_replace(home_url(), '', get_template_directory_uri()) . '/js/skip-link-focus-fix.js', array(), '20190329', true);
-	wp_enqueue_script('tna-components', 'https://cdn.nationalarchives.gov.uk/react-components/dist/website-1.1.3.js', array(), '20200608', true);
+	wp_enqueue_script('tna-components', 'https://cdn.nationalarchives.gov.uk/react-components/dist/website-1.1.4.js', array(), '20200608', true);
 
 	if (is_singular() && comments_open() && get_option('thread_comments')) {
             wp_enqueue_script('comment-reply');


### PR DESCRIPTION
Hi @JamesWChan,

Would you be able to merge this PR?

It simply updates the tna-components version to the latest one:

https://cdn.nationalarchives.gov.uk/react-components/dist/website-1.1.4.js

Thanks :+1: