### PR TITLE
Adding new 'History Hook Starter' filter etc...

### DIFF
--- a/resource-selector-form.php
+++ b/resource-selector-form.php
@@ -22,8 +22,8 @@ get_header(); ?>
 
 
 $stralltimeperiods ='medieval,early-modern,empire-and-industry,victorians,early-20th-century,interwar,second-world-war,postwar';
-$strallsessionsweteach = "workshop,video-conferences,virtual-classroom";
-$strallclassroomresources = "focussed-topics,games,lesson,themed-collection";
+$strallsessionsweteach = "workshop,workshop-send,video-conferences,virtual-classroom";
+$strallclassroomresources = "focussed-topics,games,lesson,history-hook-starter,themed-collection";
 $strsessions = "sessions-we-teach";
 $strcustomposttype = "education resource";
 
@@ -214,6 +214,15 @@ $strresourcetype = (isset($_GET["resource-type"])) ? filter_input( INPUT_GET, "r
 			$strresourcetitle = "Focussed topics";
 
 			}
+          elseif (strtolower($strresourcetitle) == "workshop-send" ) {
+              $strresourcetitle = "Workshops (SEND)";
+
+          }
+          elseif (strtolower($strresourcetitle) == "history-hook-starter" ) {
+              $strresourcetitle = "History Hook Starter";
+
+          }
+
 
 		 else{
 			 $strresourcetitle = $strresourcetitle.'s';
@@ -404,10 +413,18 @@ $tax_query = array('relation' => 'AND');
 
 	$strintro = get_sub_field('workshops');
 	}
+    elseif ($strresourcetype == "workshop-send"){
+
+        $strintro = get_sub_field('workshops-send');
+    }
 	elseif ($strresourcetype == "lesson"){
 
 	$strintro = get_sub_field('lesson');
 	}
+    elseif ($strresourcetype == "history-hook-starter"){
+
+        $strintro = get_sub_field('history_hook_starter');
+    }
 	else{
 
 	$strintro = get_sub_field('all_time_periods');
@@ -470,21 +487,23 @@ $tax_query = array('relation' => 'AND');
 </select>
 
 <select name="resource-type">
-<option selected="selected" value="workshop,video-conferences,virtual-classroom,actors,showcase,games,lesson,focussed-topics,themed-collection" >All resource types</option>
+<option selected="selected" value="workshop,workshop-send,video-conferences,virtual-classroom,actors,showcase,games,lesson,history-hook-starter,focussed-topics,themed-collection" >All resource types</option>
 <optgroup label="Classroom resources">
    <option value="lesson" <?php if ($strresourcetype =="lesson") echo "selected";?>>Lessons</option>
+    <option value="history-hook-starter" <?php if ($strresourcetype =="history-hook-starter") echo "selected";?>>History Hook Starter</option>
    <option value="themed-collection" <?php if ($strresourcetype =="themed-collection") echo "selected";?>>Themed collections</option>
 <option value="focussed-topics" <?php if ($strresourcetype =="focussed-topics") echo "selected";?>>Focussed topics</option>
  <option value="games" <?php if ($strresourcetype =="games") echo "selected";?>>Games</option>
-                <option value="focussed-topics,games,lesson,themed-collection" <?php if ($strresourcetype =="focussed-topics,games,lesson,themed-collection") echo "selected";?>>All classroom resources</option>
+                <option value="focussed-topics,games,lesson,themed-collection" <?php if ($strresourcetype =="focussed-topics,games,lesson,history-hook-starter,themed-collection") echo "selected";?>>All classroom resources</option>
                 </optgroup>
 
 
                 <optgroup label="Sessions we teach">
 <option value="workshop"  <?php if ($strresourcetype =="workshop") echo "selected";?>>Workshops</option>
+                    <option value="workshop-send"  <?php if ($strresourcetype =="workshop-send") echo "selected";?>>Workshops (SEND)</option>
                <option value="video-conferences"  <?php if ($strresourcetype =="video-conferences") echo "selected";?>>Videoconferences</option>
                <option value="virtual-classroom" <?php if ($strresourcetype =="virtual-classroom") echo "selected";?>>Virtual classroom</option>
-                <option value="workshop,video-conferences,virtual-classroom,actors" <?php if ($strresourcetype =="workshop,video-conferences,virtual-classroom,actors") echo "selected";?>>All sessions we teach</option>
+                <option value="workshop,workshop-send,video-conferences,virtual-classroom,actors" <?php if ($strresourcetype =="workshop,workshop-send,video-conferences,virtual-classroom,actors") echo "selected";?>>All sessions we teach</option>
                 </optgroup>
 
 </select>
@@ -538,10 +557,10 @@ $tax_query = array('relation' => 'AND');
 
 if($strresourcetype == "focussed-topics,games,lesson,themed-collection") {
 			   $strsub = "All".$strshowtimeperiod."classroom resources";
-		  }elseif($strresourcetype == "workshop,video-conferences,virtual-classroom,actors") {
+		  }elseif($strresourcetype == "workshop,workshop-send,video-conferences,virtual-classroom,actors") {
 			   $strsub = "All".$strshowtimeperiod."sessions we teach";
 		  }
-		  elseif($strresourcetype == "workshop,video-conferences,virtual-classroom,actors,showcase,games,lesson" or $strresourcetype == "" ) {
+		  elseif($strresourcetype == "workshop,workshop-send,video-conferences,virtual-classroom,actors,showcase,games,lesson,history-hook-starter" or $strresourcetype == "" ) {
 			   $strsub = "All".$strshowtimeperiod."resources";
 		  }
 
@@ -556,8 +575,17 @@ if($strresourcetype == "focussed-topics,games,lesson,themed-collection") {
 		 }
 		 	elseif (strtolower($strsub) == "workshop" ) {
 			$strsub = "All".$strshowtimeperiod."workshops";
-		 } 	elseif (strtolower($strsub) == "lesson" ) {
+		 }
+         elseif (strtolower($strsub) == "workshop-send" ) {
+             $strsub = "All".$strshowtimeperiod."workshops (SEND)";
+         }
+
+		 elseif (strtolower($strsub) == "lesson" ) {
 			$strsub = "All".$strshowtimeperiod."lessons";
+		 }
+
+			elseif (strtolower($strsub) == "history-hook-starter" ) {
+			$strsub = "All".$strshowtimeperiod." History Hook Starter";
 		 }
 		 elseif (strtolower($strsub) == "focussed topics" ) {
 			$strsub = "All".$strshowtimeperiod."focussed topics";
@@ -710,11 +738,16 @@ echo('<div class="pad-bottom-medium"></div>');
 					   }elseif ($term->slug =='ks1' or $term->slug =='ks2' or $term->slug =='ks3' or $term->slug =='ks4' or $term->slug =='ks5'){
 						    $stredurl = "<span class=tag><a href=?key-stage=". $term->slug.">". $stredtag."</a></span>";
 							 }
-							 elseif ($term->slug =='focussed-topics' or $term->slug =='themed-collection' or $term->slug =='lesson' or $term->slug =='workshop' or $term->slug =='virtual-classroom' ){
+							 elseif ($term->slug =='focussed-topics' or $term->slug =='themed-collection' or $term->slug =='lesson' or $term->slug =='workshop' or $term->slug =='workshop-send' or $term->slug =='virtual-classroom' or $term->slug =='history-hook-starter'){
 
-								 if ($term->slug =='focussed-topics'){
+								 if ($term->slug =='focussed-topics' or $term->slug =='history-hook-starter'){
 									  $stredurl = "<span class=tag><a href=?resource-type=". $term->slug.">". $stredtag."</a></span>";
-								 }else{
+								 }
+                                 elseif ($term->slug =='workshop-send'){
+                                     $stredurl = "<span class=tag><a href=?resource-type=". $term->slug.">". $stredtag."</a></span>";
+                                 }
+
+								 else{
 						    $stredurl = "<span class=tag><a href=?resource-type=". $term->slug.">". $stredtag."s</a></span>";
 								 }
 							 }


### PR DESCRIPTION
@AshTNA 
Updating the filter page to include a new option for 'History Hook Starter' and to reinstate the 'Workshop(SEND)' option (which was overwritten in a previous release). 


The update is on the TEST site - https://testlb.nationalarchives.gov.uk/education/sessions-and-resources/?time-period=medieval%2Cearly-modern%2Cempire-and-industry%2Cvictorians%2Cearly-20th-century%2Cinterwar%2Csecond-world-war%2Cpostwar&key-stage=ks1%2Cks2%2Cks3%2Cks4%2Cks5&resource-type=history-hook-starter#