### PR TITLE
Adding Lesson (SEND) to the filter list

### DIFF
--- a/resource-selector-form.php
+++ b/resource-selector-form.php
@@ -23,7 +23,7 @@ get_header(); ?>
 
 $stralltimeperiods ='medieval,early-modern,empire-and-industry,victorians,early-20th-century,interwar,second-world-war,postwar';
 $strallsessionsweteach = "workshop,workshop-send,video-conferences,virtual-classroom";
-$strallclassroomresources = "focussed-topics,games,lesson,history-hook-starter,time-travel-tv,themed-collection";
+$strallclassroomresources = "focussed-topics,games,lesson,history-hook-starter,time-travel-tv,lesson-send,themed-collection";
 $strsessions = "sessions-we-teach";
 $strcustomposttype = "education resource";
 
@@ -425,6 +425,10 @@ $tax_query = array('relation' => 'AND');
 
 	$strintro = get_sub_field('lesson');
 	}
+    elseif ($strresourcetype == "lesson-send"){
+
+        $strintro = get_sub_field('lesson-send');
+    }
     elseif ($strresourcetype == "history-hook-starter"){
 
         $strintro = get_sub_field('history_hook_starter');
@@ -495,15 +499,16 @@ $tax_query = array('relation' => 'AND');
 </select>
 
 <select name="resource-type">
-<option selected="selected" value="workshop,workshop-send,video-conferences,virtual-classroom,actors,showcase,games,lesson,history-hook-starter,time-travel-tv,focussed-topics,themed-collection" >All resource types</option>
+<option selected="selected" value="workshop,workshop-send,video-conferences,virtual-classroom,actors,showcase,games,lesson,history-hook-starter,time-travel-tv,lesson-send,focussed-topics,themed-collection" >All resource types</option>
 <optgroup label="Classroom resources">
    <option value="lesson" <?php if ($strresourcetype =="lesson") echo "selected";?>>Lessons</option>
+    <option value="lesson-send" <?php if ($strresourcetype =="lesson-send") echo "selected";?>>Lessons (SEND)</option>
     <option value="history-hook-starter" <?php if ($strresourcetype =="history-hook-starter") echo "selected";?>>History Hook Starter</option>
     <option value="time-travel-tv" <?php if ($strresourcetype =="time-travel-tv") echo "selected";?>>Time Travel TV</option>
    <option value="themed-collection" <?php if ($strresourcetype =="themed-collection") echo "selected";?>>Themed collections</option>
 <option value="focussed-topics" <?php if ($strresourcetype =="focussed-topics") echo "selected";?>>Focussed topics</option>
  <option value="games" <?php if ($strresourcetype =="games") echo "selected";?>>Games</option>
-                <option value="focussed-topics,games,lesson,themed-collection" <?php if ($strresourcetype =="focussed-topics,games,lesson,history-hook-starter,time-travel-tv,themed-collection") echo "selected";?>>All classroom resources</option>
+                <option value="focussed-topics,games,lesson,themed-collection,lessons-send" <?php if ($strresourcetype =="focussed-topics,games,lesson,history-hook-starter,time-travel-tv,themed-collection,lesson-send") echo "selected";?>>All classroom resources</option>
                 </optgroup>
 
 
@@ -564,12 +569,12 @@ $tax_query = array('relation' => 'AND');
 
 
 
-if($strresourcetype == "focussed-topics,games,lesson,themed-collection") {
+if($strresourcetype == "focussed-topics,games,lesson,themed-collection,lesson-send") {
 			   $strsub = "All".$strshowtimeperiod."classroom resources";
 		  }elseif($strresourcetype == "workshop,workshop-send,video-conferences,virtual-classroom,actors") {
 			   $strsub = "All".$strshowtimeperiod."sessions we teach";
 		  }
-		  elseif($strresourcetype == "workshop,workshop-send,video-conferences,virtual-classroom,actors,showcase,games,lesson,history-hook-starter" or $strresourcetype == "" ) {
+		  elseif($strresourcetype == "workshop,workshop-send,video-conferences,virtual-classroom,actors,showcase,games,lesson,history-hook-starter,lesson-send" or $strresourcetype == "" ) {
 			   $strsub = "All".$strshowtimeperiod."resources";
 		  }
 
@@ -592,7 +597,9 @@ if($strresourcetype == "focussed-topics,games,lesson,themed-collection") {
 		 elseif (strtolower($strsub) == "lesson" ) {
 			$strsub = "All".$strshowtimeperiod."lessons";
 		 }
-
+         elseif (strtolower($strsub) == "lesson-send" ) {
+             $strsub = "All".$strshowtimeperiod."lessons SEND";
+         }
 			elseif (strtolower($strsub) == "history-hook-starter" ) {
 			$strsub = "All".$strshowtimeperiod." History Hook Starter";
 		 }
@@ -750,12 +757,12 @@ echo('<div class="pad-bottom-medium"></div>');
 					   }elseif ($term->slug =='ks1' or $term->slug =='ks2' or $term->slug =='ks3' or $term->slug =='ks4' or $term->slug =='ks5'){
 						    $stredurl = "<span class=tag><a href=?key-stage=". $term->slug.">". $stredtag."</a></span>";
 							 }
-							 elseif ($term->slug =='focussed-topics' or $term->slug =='themed-collection' or $term->slug =='lesson' or $term->slug =='workshop' or $term->slug =='workshop-send' or $term->slug =='virtual-classroom' or $term->slug =='history-hook-starter' or $term->slug =='time-travel-tv'){
+							 elseif ($term->slug =='focussed-topics' or $term->slug =='themed-collection' or $term->slug =='lesson' or $term->slug =='workshop' or $term->slug =='workshop-send' or $term->slug =='virtual-classroom' or $term->slug =='history-hook-starter' or $term->slug =='time-travel-tv'  or $term->slug =='lesson-send'){
 
 								 if ($term->slug =='focussed-topics' or $term->slug =='history-hook-starter' or $term->slug =='time-travel-tv'){
 									  $stredurl = "<span class=tag><a href=?resource-type=". $term->slug.">". $stredtag."</a></span>";
 								 }
-                                 elseif ($term->slug =='workshop-send'){
+                                 elseif ($term->slug =='workshop-send' or $term->slug =='lesson-send'){
                                      $stredurl = "<span class=tag><a href=?resource-type=". $term->slug.">". $stredtag."</a></span>";
                                  }
 


### PR DESCRIPTION
Adding the option to filter by a new category called 'Lesson (Send)'. You can see it working on https://test.nationalarchives.gov.uk/education/sessions-and-resources/?time-period=medieval%2Cearly-modern%2Cempire-and-industry%2Cvictorians%2Cearly-20th-century%2Cinterwar%2Csecond-world-war%2Cpostwar&key-stage=ks1%2Cks2%2Cks3%2Cks4%2Cks5&resource-type=lesson-send#
