### PR TITLE
fixed the path to the glossary include

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -507,8 +507,7 @@ if (!function_exists('get_glossary')) :
         if (isset($atts['term']) and isset($content)) {
 
             // The inclusion of research-guide-glossary-data.php provides access to the array $glossaryDefinitions
-            $termsLoaded = include('inc/research-guide-filter/research-guide-filter-data.php');
-
+            $termsLoaded = include('inc/research-guides/research-guide-glossary-data.php');
             if ($termsLoaded != false) {
 
                 $term = $atts['term'];


### PR DESCRIPTION
Hi Chris, Ash,

In one of your changes from January this path was changed which I believe was a mistake (maybe from a find/replace?) - but it means that the glossary in the research guides hasn't been working since the terms aren't getting loaded.

This is the commit where it was changed:
https://github.com/nationalarchives/tna/commit/9cf17ae8edc632e789772f3c270d590e51e56340

Could you look at this and let me know if there was a reason this path was changed and if not could you approve and merge this?

Thanks,

Andy