### PR TITLE
Remove call that is returning errors

### DIFF
--- a/inc/rss-feeds.php
+++ b/inc/rss-feeds.php
@@ -119,8 +119,9 @@ if (!function_exists('add_featured_image_to_rss')) :
 		if ( function_exists( 'has_post_thumbnail' ) and has_post_thumbnail() ) {
 			$featured_image = str_replace( site_url(), 'https://www.nationalarchives.gov.uk', wp_get_attachment_image_src( get_post_thumbnail_id(), 'post-thumbnail' ));
 			$mime_type = get_post_mime_type(get_post_thumbnail_id());
-			$headers = get_headers($featured_image[0], 1);
-			echo "\t" . '<enclosure url="' . $featured_image[0] . '" length="' . $headers["Content-Length"] . '" type="' . $mime_type . '" />' . "\n";
+			/* this is broken - possibly since php 5.6 so removing 2020-12-04
+			$headers = get_headers($featured_image[0], 1); */
+			echo "\t" . '<enclosure url="' . $featured_image[0] . '" length="120000" type="' . $		
 		}
 	}
 	add_action( 'rss2_item', 'add_featured_image_to_rss' );


### PR DESCRIPTION
The call to get_headers is throwing an error related to certificates - as it's not working this is to temporarily remove the call until we can fix it - this call populated the length attribute in the enclosure tag - the attribute is required and must be a positive integer - I have popped in 120000b - which will hopefully cover this for now (120k seems reasonable for an image!?

Currently the length attribute in our existing code is returning empty `length=""` which is even less right!