### PR TITLE
Education bundle adding max-width

### DIFF
--- a/css/education-bundles-temp.css
+++ b/css/education-bundles-temp.css
@@ -54,7 +54,7 @@ height: 360px;
 display: block;
 margin: 0 auto;
 width: auto;
-max-width: inherit;
+max-width: 790px;
 }
 
 .bundle-viewer img {


### PR DESCRIPTION
Fixing the max-width so that new larger images (for Letters of Lockdown etc.) fit in the viewer