### PR TITLE
Adding height to bundle viewer

### DIFF
--- a/css/education-bundles-temp.css
+++ b/css/education-bundles-temp.css
@@ -54,7 +54,7 @@ height: 360px;
 display: block;
 margin: 0 auto;
 width: auto;
-max-width: 790px;
+max-height:540px;
 }
 
 .bundle-viewer img {


### PR DESCRIPTION
Last fix didn't work for some of the taller images on older resources, so switching to a max-height instead.