### PR TITLE
Replace jQuery width() with DOM innerWidth

### DIFF
--- a/scripts/mega-menu.js
+++ b/scripts/mega-menu.js
@@ -21,7 +21,7 @@ $.fn.mega_menu_enhancements = function () {
             return;
         }
 
-        if ($(window).width() <= 480) {
+        if (window.innerWidth <= 480) {
             var $this = $(this);
             e.preventDefault();
             $this.toggleClass('expanded').next().slideToggle('fast');

--- a/scripts/tna-bindings.js
+++ b/scripts/tna-bindings.js
@@ -23,7 +23,7 @@ $(window).on({
     resize: function() {
         $.moreLinkFocusManager();
 
-        if($(window).width() > 480){
+        if(window.innerWidth > 480){
             $('.mega-menu ul').show();
         }
     }

--- a/scripts/tna-definitions.js
+++ b/scripts/tna-definitions.js
@@ -366,7 +366,7 @@ tnaCheckForThisCookie = function(name) {
 $.moreLinkFocusManager = function() {
 
   $('#more-link').attr('tabindex', function () {
-    return $(window).width() > 480 ? '-1' : '0';
+    return window.innerWidth > 480 ? '-1' : '0';
   });
 };
 


### PR DESCRIPTION
This is to address an issue present in Windows where the presence of the scrollbar causes the width() to be different to CSS media calculation of width.