### PR TITLE
Add Etna beta analytics cookie to delete function

### DIFF
--- a/inc/functions-cookies.php
+++ b/inc/functions-cookies.php
@@ -5,7 +5,7 @@
 // Delete Google Analytics cookies on WP init
 function delete_GA_cookies() {
 	$domain = 'nationalarchives.local';
-	$cookie_list = ['_ga', '_gid', '_gat_UA-2827241-22', '_gat_UA-2827241-1'];
+	$cookie_list = ['_ga', '_gid', '_gat_UA-2827241-22', '_gat_UA-2827241-1', '_ga_2CP7QT8TDG'];
 	handle_cookies($cookie_list, $domain);
 }
 


### PR DESCRIPTION
Hi @JamesWChan 

Similar to the tna-base PR, this adds the Etna beta analytics cookie to the deletion function, which ensures that if the user has rejected cookies, the cookies are deleted on page load if they exist.

Would you be able to merge if all is OK?

Thanks :+1: