### PR TITLE
Upping result limit from 250 to 350

### DIFF
--- a/resource-selector-form.php
+++ b/resource-selector-form.php
@@ -339,7 +339,7 @@ $tax_query = array('relation' => 'AND');
  $loop = new WP_Query(
     array(
         'post_type' => 'page',
-        'posts_per_page' => '250',
+        'posts_per_page' => '350',
         'tax_query' => $tax_query,
 		    'orderby'=> 'title',
         'order' => 'ASC'


### PR DESCRIPTION
Increasing the number of records result in the query, so that all items can be displayed on the Education page. Currently there are 316 but the 250 limit prevents the others from appearing (as there is no paging).