### PR TITLE
WCAG 2.2 fixes for 55 (DSOPS-457) - and 58 (DSOPS-459)  

### DIFF
--- a/research-guide-keywords.php
+++ b/research-guide-keywords.php
@@ -152,9 +152,9 @@ foreach ( $terms_array as $tterm ) {
 if ($reskeyword == $termslug){
 
     // echo '<li><b>'. $termname. '</b></li>';
-    echo '<li><a href="?show=keywords&keyword-letter='.$reskeyletter.'&keyword='.$termslug.'#step-three" autofocus><strong>'. $termname. '</strong></a></li>';
+    echo '<li><a aria-selected="true" href="?show=keywords&keyword-letter='.$reskeyletter.'&keyword='.$termslug.'#step-three" autofocus><strong>'. $termname. '</strong></a></li>';
 }else{
-echo '<li><a href="?show=keywords&keyword-letter='.$reskeyletter.'&keyword='.$termslug.'#step-three">'. $termname. '</a></li>';
+echo '<li><a aria-selected="true" href="?show=keywords&keyword-letter='.$reskeyletter.'&keyword='.$termslug.'#step-three">'. $termname. '</a></li>';
 
 
 }

--- a/scripts/accessible-glossary-terms.js
+++ b/scripts/accessible-glossary-terms.js
@@ -45,10 +45,10 @@ $(function() {
                     $term.text('charges apply');
                     $term.attr('aria-label', $term.attr('title'));
 
-                    $term.on('click', function() {
-
-                        alert($(this).attr('title'));
-                    });
+                    // $term.on('click', function() {
+                    //
+                    //     alert($(this).attr('title'));
+                    // });
                 }
             });
         }


### PR DESCRIPTION

_55 - Visually selected options_ - `aria-selected="true"` has been added to the links to ensure state of the element is relayed programmatically. Tested on https://dev-www.nationalarchives.gov.uk/help-with-your-research/research-guides-keywords/?show=keywords&keyword-letter=f&keyword=first-world-war#step-three


_58 - Non-focusable alert_ -  the JS alert has been disabled. Tested on https://dev-www.nationalarchives.gov.uk/help-with-your-research/research-guides/women-in-british-army/

